### PR TITLE
Added support for glossaries / glossaries-extra

### DIFF
--- a/src/latex_dependency_scanner/scanner.py
+++ b/src/latex_dependency_scanner/scanner.py
@@ -37,10 +37,10 @@ COMMON_EXTENSIONS_IN_TEX = (
 
 REGEX_TEX = re.compile(
     r"\\(?P<type>usepackage|RequirePackage|include|addbibresource|bibliography|putbib|"
-    r"includegraphics|input|(sub)?import|lstinputlisting)"
+    r"includegraphics|input|(sub)?import|lstinputlisting|glsxtrresourcefile|GlsXtrLoadResources)"
     r"(<[^<>]*>)?"
     r"(\[[^\[\]]*\])?"
-    r"({(?P<relative_to>[^{}]*)})?{(?P<file>[^{}]*)}",
+    r"({(?P<relative_to>[^{}]*)})?(\[[^\[\]]*src=)?{(?P<file>[^{}]*)}",
     re.M,
 )
 """re.Pattern: The regular expression pattern to extract included files from a LaTeX

--- a/src/latex_dependency_scanner/scanner.py
+++ b/src/latex_dependency_scanner/scanner.py
@@ -9,7 +9,6 @@ from typing import Union
 COMMON_TEX_EXTENSIONS = [".ltx", ".tex"]
 """List[str]: List of typical file extensions that contain latex"""
 
-
 COMMON_GRAPHICS_EXTENSIONS = [
     # Image formats.
     ".eps",
@@ -20,20 +19,18 @@ COMMON_GRAPHICS_EXTENSIONS = [
 ]
 """List[str]: List of typical image extensions contained in LaTeX files."""
 
-
 COMMON_EXTENSIONS_IN_TEX = (
-    [
-        # No extension if the extension is provided.
-        "",
-        # TeX formats.
-        ".bib",
-        ".sty",
-    ]
-    + COMMON_GRAPHICS_EXTENSIONS
-    + COMMON_TEX_EXTENSIONS
+        [
+            # No extension if the extension is provided.
+            "",
+            # TeX formats.
+            ".bib",
+            ".sty",
+        ]
+        + COMMON_GRAPHICS_EXTENSIONS
+        + COMMON_TEX_EXTENSIONS
 )
 """List[str]: List of typical file extensions included in latex files"""
-
 
 REGEX_TEX = re.compile(
     r"\\(?P<type>usepackage|RequirePackage|include|addbibresource|bibliography|putbib|"
@@ -69,9 +66,9 @@ def scan(paths: Union[Path, List[Path]]):
 
 
 def yield_nodes_from_node(
-    node: Path,
-    nodes: List[Path],
-    relative_to: Optional[Path] = None,
+        node: Path,
+        nodes: List[Path],
+        relative_to: Optional[Path] = None,
 ):
     r"""Yield nodes from node.
 
@@ -137,6 +134,8 @@ def yield_nodes_from_node(
                         common_extensions = [ext]
                     else:
                         common_extensions = COMMON_GRAPHICS_EXTENSIONS
+                elif match.group("type") in ["glsxtrresourcefile", "GlsXtrLoadResources"]:
+                    common_extensions = [".glstex", ".bib"]  # .bib for bib2gls
                 elif match.group("type") == "lstinputlistings":
                     common_extensions = [""]
                 else:

--- a/tests/resources/acronyms.glstex
+++ b/tests/resources/acronyms.glstex
@@ -1,0 +1,1 @@
+\newabbreviation{abc}{ABC}{AlphaBetaGamma}

--- a/tests/resources/symbols.bib
+++ b/tests/resources/symbols.bib
@@ -1,0 +1,5 @@
+@symbol{Ab,
+    name = {\ensuremath{A_b}},
+    description = {Symbol Ab},
+}
+

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -57,6 +57,14 @@ from latex_dependency_scanner.scanner import REGEX_TEX
             "\\addbibresource{bibfile}",
             {"type": "addbibresource", "file": "bibfile", "relative_to": None},
         ),
+        (
+            "\\glsxtrresourcefile{glsfile}",
+            {"type": "glsxtrresourcefile", "file": "glsfile", "relative_to": None},
+        ),
+        (
+            "\\GlsXtrLoadResources[src={glsfile}]",
+            {"type": "GlsXtrLoadResources", "file": "glsfile", "relative_to": None},
+        ),
     ],
 )
 def test_regex_tex(text, expected):

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -390,3 +390,68 @@ def test_biblatex_bibliography_without_extension_and_file(tmp_path):
     nodes = scan(tmp_path / "document.tex")
 
     assert nodes == [tmp_path / "document.tex", tmp_path / "bibliography.bib"]
+
+
+@pytest.mark.end_to_end
+def test_glossaries(tmp_path):
+    """Test document with glossaries"""
+    source = """
+    \\documentclass{article}
+    \\usepackage{glossaries}
+    \\glsxtrresourcefile{symbols}
+    \\GlsXtrLoadResources[src={acronyms}]
+    \\begin{document}
+    \\printunsrtsymbols
+    \\printunsrtglossaries
+    \\end{document}
+    """
+    tmp_path.joinpath("document.tex").write_text(textwrap.dedent(source))
+    shutil.copy(TEST_RESOURCES / "symbols.bib", tmp_path / "symbols.bib")
+    shutil.copy(TEST_RESOURCES / "acronyms.glstex", tmp_path / "acronyms.glstex")
+
+    nodes = scan(tmp_path / "document.tex")
+
+    assert nodes == [tmp_path / "document.tex", tmp_path / "symbols.bib", tmp_path / "acronyms.glstex"]
+
+
+@pytest.mark.end_to_end
+def test_glossaries_both_extensions_present(tmp_path):
+    """Test document with glossaries and present files symbols.bib AND symbols.glstex"""
+    source = """
+    \\documentclass{article}
+    \\usepackage{glossaries}
+    \\glsxtrresourcefile{symbols}
+    \\begin{document}
+    \\printunsrtsymbols
+    \\printunsrtglossaries
+    \\end{document}
+    """
+    tmp_path.joinpath("document.tex").write_text(textwrap.dedent(source))
+    shutil.copy(TEST_RESOURCES / "symbols.bib", tmp_path / "symbols.bib")
+    shutil.copy(TEST_RESOURCES / "acronyms.glstex", tmp_path / "symbols.glstex")
+
+    nodes = scan(tmp_path / "document.tex")
+    print(nodes)
+
+    assert nodes == [tmp_path / "document.tex", tmp_path / "symbols.glstex"]
+
+
+@pytest.mark.end_to_end
+def test_glossaries_without_files(tmp_path):
+    """Test document with glossaries"""
+    source = """
+    \\documentclass{article}
+    \\usepackage{glossaries}
+    \\glsxtrresourcefile{symbols}
+    \\GlsXtrLoadResources[src={acronyms}]
+    \\begin{document}
+    \\printunsrtsymbols
+    \\printunsrtglossaries
+    \\end{document}
+    """
+    tmp_path.joinpath("document.tex").write_text(textwrap.dedent(source))
+
+    nodes = scan(tmp_path / "document.tex")
+
+    assert nodes == [tmp_path / "document.tex", tmp_path / "symbols.glstex", tmp_path / "symbols.bib",
+                     tmp_path / "acronyms.glstex", tmp_path / "acronyms.bib"]


### PR DESCRIPTION
#### Changes

Recently I stumbled about pytask and pytask-latex and found it very useful. Unfortunately I missed support for glossaries in dependency scanning, since I use the package extensively.
I changed the regex and the scan method to recognize `\glsxtrresourcefile` and `\GlsXtrLoadResources` and search for *.glstex and *.bib files with the specified names (*.bib is for use with bib2gls).

#### Todo

- [ ] Reference issues which can be closed due to this PR with "Closes #x".
- [ ] Review whether the documentation needs to be updated.
- [ ] Document PR in docs/changes.rst.
